### PR TITLE
Fix delete slot

### DIFF
--- a/HouseHotkey.addon
+++ b/HouseHotkey.addon
@@ -1,7 +1,7 @@
 ## Title: House Hotkey
 ## Author: @thisbeaurielle
 ## Version: 1.0.0
-## APIVersion: 101045 101046
+## APIVersion: 101045 101046 101047
 ## AddOnVersion: 1
 ## SavedVariables: HouseHotkey_Vars
 ## DependsOn: LibHarvensAddonSettings

--- a/HouseHotkey.lua
+++ b/HouseHotkey.lua
@@ -466,7 +466,7 @@ if #houseItems > 0 then
     default = GetString(SI_HOTBARCATEGORY10),
   }
   --Index
-  panel:AddSetting {
+  local entryIndexDropdown = panel:AddSetting {
     type = LAM.ST_DROPDOWN,
     label = HH.Lang.WHEEL_SLOT,
     items = {
@@ -504,6 +504,9 @@ if #houseItems > 0 then
     clickHandler = function()
       if EntryIndex2 then
         HH.SV.Command[Category2 or HOTBAR_CATEGORY_QUICKSLOT_WHEEL][EntryIndex2] = nil
+        panel:UpdateControls()
+      elseif entryIndexDropdown:getFunction() == "1 - N" then
+        HH.SV.Command[Category2 or HOTBAR_CATEGORY_QUICKSLOT_WHEEL][4] = nil
         panel:UpdateControls()
       end
     end,

--- a/HouseHotkey.lua
+++ b/HouseHotkey.lua
@@ -502,8 +502,10 @@ if #houseItems > 0 then
     label = HH.Lang.WHEEL_DELETE,
     buttonText = HH.Lang.WHEEL_DELETE,
     clickHandler = function()
-      HH.SV.Command[Category2 or HOTBAR_CATEGORY_QUICKSLOT_WHEEL][EntryIndex2 or 4] = nil
-      panel:UpdateControls()
+      if EntryIndex2 then
+        HH.SV.Command[Category2 or HOTBAR_CATEGORY_QUICKSLOT_WHEEL][EntryIndex2] = nil
+        panel:UpdateControls()
+      end
     end,
   }
   else


### PR DESCRIPTION
This PR fixes the issue in which if you do not actively select "1 - N" in the delete slot submenu it would not delete anything or would delete the wrong slot.